### PR TITLE
refactor: use requirements.txt and prepare for GitHub Actions extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ local.properties
 *.log
 /config_settings.yaml
 .venv/
-I18N/
+i18n/
 **/values-*/strings.xml

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,12 @@
 clean_translations_temp_directory:
-	rm -rf I18N/
+	rm -rf i18n/
 
-create_virtual_env:
-	rm -rf .venv
-	python3 -m venv .venv
-	# TODO: Publish new version on pypi as `python3-localizable`
-	. .venv/bin/activate && pip install openedx-atlas
-	. .venv/bin/activate && pip install lxml
+translation_requirements:
+	pip install -r i18n_scripts/requirements.txt
 
-pull_translations: clean_translations_temp_directory create_virtual_env
-	. .venv/bin/activate && atlas pull $(ATLAS_OPTIONS) translations/openedx-app-android/I18N:I18N
-	. .venv/bin/activate && python i18n_scripts/translation_script.py --split
-	make clean_translations_temp_directory
+pull_translations: clean_translations_temp_directory
+	atlas pull $(ATLAS_OPTIONS) translations/openedx-app-android/i18n:i18n
+	python i18n_scripts/translation_script.py --split
 
-
-extract_translations: clean_translations_temp_directory create_virtual_env
-	. .venv/bin/activate && python i18n_scripts/translation_script.py --extract
+extract_translations: clean_translations_temp_directory
+	python i18n_scripts/translation_script.py --extract

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ translation_requirements:
 
 pull_translations: clean_translations_temp_directory
 	atlas pull $(ATLAS_OPTIONS) translations/openedx-app-android/i18n:i18n
-	python i18n_scripts/translation_script.py --split
+	python i18n_scripts/translation.py --split
 
 extract_translations: clean_translations_temp_directory
-	python i18n_scripts/translation_script.py --extract
+	python i18n_scripts/translation.py --extract

--- a/i18n_scripts/requirements.txt
+++ b/i18n_scripts/requirements.txt
@@ -1,0 +1,2 @@
+openedx-atlas==0.6.0
+lxml==5.2.2

--- a/i18n_scripts/translation.py
+++ b/i18n_scripts/translation.py
@@ -8,11 +8,11 @@ This script is designed to manage translations for a project by performing two o
 ## Usage
 
 ```bash
-python translation_script.py --extract
+python translation.py --extract
 
 or
 
-python translation_script.py --split
+python translation.py --split
 
 """
 import argparse
@@ -100,10 +100,10 @@ def get_modules_to_translate(modules_dir):
     Returns:
         list of str: A list of module names.
     """
-    # Get all directories within the modules directory except for 'I18N'
+    # Get all directories within the modules directory except for 'i18n'
     dirs = [
         directory for directory in os.listdir(modules_dir)
-        if os.path.isdir(os.path.join(modules_dir, directory)) and directory != 'I18N'
+        if os.path.isdir(os.path.join(modules_dir, directory)) and directory != 'i18n'
     ]
 
     modules_list = []
@@ -182,7 +182,7 @@ def combine_translation_files(modules_dir=None):
     if not modules_dir:
         modules_dir = os.path.dirname(os.path.dirname(__file__))
     combined_root_element = combine_translations(modules_dir)
-    write_translation_file(modules_dir, combined_root_element, 'I18N', 'values')
+    write_translation_file(modules_dir, combined_root_element, 'i18n', 'values')
 
 
 def get_languages_dirs(modules_dir):
@@ -202,7 +202,7 @@ def get_languages_dirs(modules_dir):
         Output:
             ['values-ar', 'values-uk', ...]
     """
-    lang_parent_dir = os.path.join(modules_dir, 'I18N', 'src', 'main', 'res')
+    lang_parent_dir = os.path.join(modules_dir, 'i18n', 'src', 'main', 'res')
     languages_dirs = [
         directory for directory in os.listdir(lang_parent_dir)
         if (
@@ -231,7 +231,7 @@ def separate_translation_to_modules(modules_dir, lang_dir):
     """
     translations_roots = {}
     # Parse the translation file
-    file_path = os.path.join(modules_dir, 'I18N', 'src', 'main', 'res', lang_dir, 'strings.xml')
+    file_path = os.path.join(modules_dir, 'i18n', 'src', 'main', 'res', lang_dir, 'strings.xml')
     module_translations_tree = etree.parse(file_path)
     root = module_translations_tree.getroot()
     previous_entry = None
@@ -297,4 +297,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/i18n_scripts/translation.py
+++ b/i18n_scripts/translation.py
@@ -180,7 +180,7 @@ def combine_translation_files(modules_dir=None):
     Combine translation files from different modules into a single file.
     """
     if not modules_dir:
-        modules_dir = os.path.dirname(os.path.dirname(__file__))
+        modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     combined_root_element = combine_translations(modules_dir)
     write_translation_file(modules_dir, combined_root_element, 'i18n', 'values')
 

--- a/i18n_scripts/translation.py
+++ b/i18n_scripts/translation.py
@@ -264,7 +264,7 @@ def split_translation_files(modules_dir=None):
     """
     # Set the modules directory if not provided
     if not modules_dir:
-        modules_dir = os.path.dirname(os.path.dirname(__file__))
+        modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     # Get the directories containing language files
     languages_dirs = get_languages_dirs(modules_dir)


### PR DESCRIPTION
### Changes

 - Use requirements file
 - Lower case `i18n` module is preferred for android for consistency
 - Remove `clean_translations_temp_directory` after `pull_translations`
 - Avoid using `create_virtual_env` in favor of manual steps to accommodate for GitHub Actions
 - Rename to `translation.py`
